### PR TITLE
[BulkApi] Implement Query Mocking

### DIFF
--- a/simple_mockforce/__init__.py
+++ b/simple_mockforce/__init__.py
@@ -7,6 +7,7 @@ from simple_mockforce.callbacks import (
     bulk_callback,
     bulk_detail_callback,
     bulk_result_callback,
+    bulk_query_result_callback,
     create_callback,
     delete_callback,
     get_callback,
@@ -19,6 +20,7 @@ from simple_mockforce.callbacks import (
 from simple_mockforce.constants import (
     BATCH_DETAIL_URL,
     BATCH_RESULT_URL,
+    BATCH_QUERY_RESULT_URL,
     CREATE_URL,
     JOB_DETAIL_URL,
     LOGIN_URL,
@@ -92,6 +94,12 @@ def mock_salesforce(func, *args, **kwargs):
         responses.GET,
         terminate_regex(BATCH_RESULT_URL),
         callback=bulk_result_callback,
+        content_type="content/json",
+    )
+    responses.add_callback(
+        responses.GET,
+        terminate_regex(BATCH_QUERY_RESULT_URL),
+        callback=bulk_query_result_callback,
         content_type="content/json",
     )
     responses.add_callback(

--- a/simple_mockforce/callbacks.py
+++ b/simple_mockforce/callbacks.py
@@ -283,11 +283,7 @@ def bulk_result_callback(request):
 def bulk_query_result_callback(request):
     path = urlparse(request.url).path
 
-    job_id, batch_id, result_set_id = parse_batch_query_result_url(path)
-
-    job = virtual_salesforce.jobs[job_id]
-    assert job["operation"] == "query"
-
+    _, batch_id, result_set_id = parse_batch_query_result_url(path)
     data = virtual_salesforce.batch_data[batch_id][result_set_id]
 
     return (

--- a/simple_mockforce/callbacks.py
+++ b/simple_mockforce/callbacks.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from simple_mockforce.error_codes import NOT_FOUND
 from simple_mockforce.utils import (
     parse_batch_detail_url,
+    parse_batch_query_result_url,
     parse_batch_result_url,
     parse_detail_url,
     parse_create_url,
@@ -150,13 +151,18 @@ def job_callback(request):
 def bulk_callback(request):
     url = request.url
     path = urlparse(url).path
-    body = json.loads(request.body)
 
     job_id = parse_job_batch_url(path)
     job = virtual_salesforce.jobs[job_id]
     operation = job["operation"]
 
-    batch = virtual_salesforce.create_batch(job_id, body, operation)
+    if operation == "query":
+        # For testing purposes we only return one results set.
+        data = {"752x00000004CJE": virtual_salesforce.query(request.body)}
+    else:
+        data = json.loads(request.body)
+
+    batch = virtual_salesforce.create_batch(job_id, data, operation)
 
     return (
         201,
@@ -193,7 +199,17 @@ def bulk_result_callback(request):
     job = virtual_salesforce.jobs[job_id]
     sobject_name = job["object"]
     operation = job["operation"]
+
     data = virtual_salesforce.batch_data[batch_id]
+
+    if operation == "query":
+        return (
+            201,
+            {},
+            # Keys of the query data are result set ids
+            json.dumps(list(data.keys()))
+        )
+
 
     id_to_created = dict()
 
@@ -261,6 +277,23 @@ def bulk_result_callback(request):
         201,
         {},
         json.dumps(fake_response),
+    )
+
+
+def bulk_query_result_callback(request):
+    path = urlparse(request.url).path
+
+    job_id, batch_id, result_set_id = parse_batch_query_result_url(path)
+
+    job = virtual_salesforce.jobs[job_id]
+    assert job["operation"] == "query"
+
+    data = virtual_salesforce.batch_data[batch_id][result_set_id]
+
+    return (
+        201,
+        {},
+        json.dumps(data),
     )
 
 

--- a/simple_mockforce/constants.py
+++ b/simple_mockforce/constants.py
@@ -22,6 +22,7 @@ BATCH_DETAIL_URL = (
 BATCH_RESULT_URL = (
     f"{BASE_URL}/services/async/{SF_VERSION}/job/{SFDC_ID}/batch/{SFDC_ID}/result"
 )
+BATCH_QUERY_RESULT_URL = f"{BATCH_RESULT_URL}/{SFDC_ID}"
 
 
 # login stuff

--- a/simple_mockforce/utils.py
+++ b/simple_mockforce/utils.py
@@ -42,6 +42,13 @@ def parse_batch_result_url(url: str):
     batch_id = split_up[-2]
     return job_id, batch_id
 
+def parse_batch_query_result_url(url: str):
+    split_up = url.split("/")
+    job_id = split_up[-5]
+    batch_id = split_up[-3]
+    result_set_id = split_up[-1]
+    return job_id, batch_id, result_set_id
+
 
 def find_object_and_index(objects: list, pk_name: str, pk: str):
     index = None

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -224,8 +224,9 @@ def test_bulk_upsert_with_duplicate_items_in_batch():
         assert record["errors"][0]["statusCode"] == "DUPLICATE_EXTERNAL_ID"
 
 
+@pytest.mark.parametrize("lazy_operation", [True, False])
 @mock_salesforce
-def test_bulk_query_lazy() -> None:
+def test_bulk_query(lazy_operation: bool) -> None:
     salesforce = Salesforce(**MOCK_CREDS)
 
     spaceship_insert_results = salesforce.bulk.Spaceship__c.insert(
@@ -258,7 +259,7 @@ def test_bulk_query_lazy() -> None:
         ]
     )
 
-    batches = salesforce.bulk.Contact.query(
+    query_results = salesforce.bulk.Contact.query(
         """SELECT
             Name,
             Occupation,
@@ -266,77 +267,18 @@ def test_bulk_query_lazy() -> None:
         FROM Contact
         WHERE Occupation = 'Smuggler'
         ORDER BY Name""",
-        lazy_operation=True,
+        lazy_operation=lazy_operation,
     )
 
-    batches_list = list(batches)
 
-    assert len(batches_list) == 1
-
-    batch = batches_list[0]
+    if lazy_operation:
+        batches_list = list(query_results)
+        assert len(batches_list) == 1
+        batch = batches_list[0]
+    else:
+        batch = query_results
 
     assert batch == [
-        {
-            "Name": "Chewbacca",
-            "Occupation": "Smuggler",
-            "Spaceship__r": {"Name": "Millenium Falcon"},
-        },
-        {
-            "Name": "Han Solo",
-            "Occupation": "Smuggler",
-            "Spaceship__r": {"Name": "Millenium Falcon"},
-        },
-    ]
-
-
-@mock_salesforce
-def test_bulk_query_not_lazy() -> None:
-    salesforce = Salesforce(**MOCK_CREDS)
-
-    spaceship_insert_results = salesforce.bulk.Spaceship__c.insert(
-        [
-            {"Name": "Millenium Falcon", "KesselRunParsecs": 12},
-            {"Name": "Lady Luck", "KesselRunParsecs": 14},
-        ]
-    )
-
-    millenium_falcon_id = spaceship_insert_results[0]["id"]
-    lady_luck_id = spaceship_insert_results[1]["id"]
-
-    salesforce.bulk.Contact.insert(
-        [
-            {
-                "Name": "Chewbacca",
-                "Occupation": "Smuggler",
-                "Spaceship__c": millenium_falcon_id,
-            },
-            {
-                "Name": "Han Solo",
-                "Occupation": "Smuggler",
-                "Spaceship__c": millenium_falcon_id,
-            },
-            {
-                "Name": "Lando Calrissian",
-                "Occupation": "Gas Mining Station Governor",
-                "Spaceship__c": lady_luck_id,
-            },
-        ]
-    )
-
-    records = salesforce.bulk.Contact.query(
-        """SELECT
-            Name,
-            Occupation,
-            Spaceship__r.Name
-        FROM Contact
-        WHERE Occupation = 'Smuggler'
-        ORDER BY Name""",
-        lazy_operation=False,
-    )
-
-    assert len(records) == 2
-
-    assert records == [
         {
             "Name": "Chewbacca",
             "Occupation": "Smuggler",


### PR DESCRIPTION
Implements the basics for responding to Bulk API (v1) Query requests.

Requests are outlined [here](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_using_bulk_query.htm).

I took the simplest approach of only returning a single result set no matter how many records are returned. In reality, there is a limit of 10,000 records per result set, and the person firing the request can set the batch size via parameter.

This could be expanded to respond properly to that parameter, but I'd like to keep this simple for now. I believe this should cover most folks test cases.